### PR TITLE
Adjust "Set the world type..." message for clarity

### DIFF
--- a/uk/co/jacekk/bukkit/SkylandsPlus/listeners/WorldListener.java
+++ b/uk/co/jacekk/bukkit/SkylandsPlus/listeners/WorldListener.java
@@ -38,7 +38,7 @@ public class WorldListener implements Listener {
 				
 				type.set(worldServer.worldData, WorldType.NORMAL);
 				
-				plugin.log.info("Set the world type of '" + world.getName() + "' to normal (this is required for custom biomes to work).");
+				plugin.log.info("We have set the world type of '" + world.getName() + "' to normal (this is required for custom biomes to work).");
 			}catch (Exception e){
 				plugin.log.info("Could not change the world type of '" + world.getName() + "'.");
 				e.printStackTrace();


### PR DESCRIPTION
The message "Set the world type..." wasn't clear on whether it was asking me to set the type or that it had set the type. Had to come browser the source to figure it out.
