### PR TITLE
Don't spawn snow over ice & liquids

### DIFF
--- a/src/main/java/uk/co/jacekk/bukkit/skylandsplus/generation/SnowPopulator.java
+++ b/src/main/java/uk/co/jacekk/bukkit/skylandsplus/generation/SnowPopulator.java
@@ -19,14 +19,18 @@ public class SnowPopulator extends BlockPopulator {
 		for (int x = 0; x < 16; ++x){
 			for (int z = 0; z < 16; ++z){
 				Biome biome = world.getBiome(chunkX + x, chunkZ + z);
-				
-				if (biome == Biome.ICE_PLAINS || biome == Biome.ICE_MOUNTAINS || biome == Biome.TAIGA || biome == Biome.TAIGA_HILLS || biome == Biome.FROZEN_OCEAN || biome == Biome.FROZEN_RIVER){
+
+				if (biome == Biome.ICE_PLAINS || biome == Biome.ICE_MOUNTAINS ||
+						biome == Biome.TAIGA || biome == Biome.TAIGA_HILLS ||
+						biome == Biome.FROZEN_OCEAN || biome == Biome.FROZEN_RIVER){
 					int y = world.getHighestBlockYAt(chunkX + x, chunkZ + z);
-					
+
 					if (y > 5){
 						Block block = chunk.getBlock(x, y, z);
-						
-						if (block.getRelative(BlockFace.DOWN).getType() != Material.AIR){
+
+						Block down = block.getRelative(BlockFace.DOWN);
+						if ( !( down.isEmpty() || down.isLiquid() ||
+								down.getType() == Material.ICE ) ){
 							block.setType(Material.SNOW);
 						}
 					}


### PR DESCRIPTION
Fixes #83

This patch has been tested with a custom world generator. Before merging it should be double-checked that frozen ocean and frozen river biomes look as expected in Skylands+ worlds (eg should contain ice above water and snow above land).
