### PR TITLE
Fix a couple lines using == instead of .equals()

### DIFF
--- a/src/main/java/uk/co/jacekk/bukkit/skylandsplus/generation/ChunkGenerator.java
+++ b/src/main/java/uk/co/jacekk/bukkit/skylandsplus/generation/ChunkGenerator.java
@@ -102,9 +102,9 @@ public class ChunkGenerator extends org.bukkit.generator.ChunkGenerator {
 			}else if (tokens[i].equals("no-ocean")){
 				no_ocean = true;
 				ocean = Biome.PLAINS;
-			}else if (tokens[i] == "mushroom"){
+			}else if (tokens[i].equals("mushroom")){
 				no_mushroom = false;
-			}else if (tokens[i] == "swampland"){
+			}else if (tokens[i].equals("swampland")){
 				no_swampland = false;
 			}else if (tokens[i].matches("only={1}[A-Z_]+")){
 				only = true;


### PR DESCRIPTION
I was going to use this generator as part of the Aether in my plugin when I stumbled across these two lines which were mistakes.
